### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function caught<T>(promise: Promise<T>): Promise<T>;
+
+export = caught;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "Avoids UnhandledPromiseRejectionWarning and PromiseRejectionHandledWarning",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "bash test.sh"
   },


### PR DESCRIPTION
With this change, anyone who has done `npm install caught` can now write this in TypeScript:
```ts
import caught = require('caught');

// Works out of the box:
const p = caught(Promise.reject(0));
setTimeout(() => p.catch(e => console.error('caught')), 0);
```